### PR TITLE
Add Apache 2 license header to files, keep default LICENSE template.

### DIFF
--- a/AI/convert_data.py
+++ b/AI/convert_data.py
@@ -1,3 +1,19 @@
+"""
+   Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
 # Importing packages
 import numpy as np
 import matplotlib.pyplot as plt

--- a/AI/evaluate_confusion_matrix.py
+++ b/AI/evaluate_confusion_matrix.py
@@ -1,3 +1,19 @@
+"""
+   Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
 # Importing packages
 import time
 

--- a/AI/train.py
+++ b/AI/train.py
@@ -1,3 +1,19 @@
+"""
+   Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
 # Importing packages
 import time
 import numpy as np

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.dell.retrofit">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/Android/app/src/main/java/com/example/dell/retrofit/MainActivity.java
+++ b/Android/app/src/main/java/com/example/dell/retrofit/MainActivity.java
@@ -1,3 +1,19 @@
+/*
+   Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 package com.example.dell.retrofit;
 import android.app.Activity;
 import android.app.ProgressDialog;

--- a/Android/app/src/main/java/com/example/dell/retrofit/MyApplication.java
+++ b/Android/app/src/main/java/com/example/dell/retrofit/MyApplication.java
@@ -1,3 +1,19 @@
+/*
+   Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 package com.example.dell.retrofit;
 
 import android.app.Application;

--- a/Android/app/src/main/java/com/example/dell/retrofit/QuestionActivity.java
+++ b/Android/app/src/main/java/com/example/dell/retrofit/QuestionActivity.java
@@ -1,3 +1,19 @@
+/*
+   Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 package com.example.dell.retrofit;
 
 import android.annotation.SuppressLint;

--- a/Android/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/Android/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,3 +1,19 @@
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"

--- a/Android/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/Android/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/Android/app/src/main/res/drawable/image_border.xml
+++ b/Android/app/src/main/res/drawable/image_border.xml
@@ -1,4 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="#FFFFFF" />
     <stroke android:width="1dp" android:color="#e1dfdf" />

--- a/Android/app/src/main/res/drawable/image_button_style.xml
+++ b/Android/app/src/main/res/drawable/image_button_style.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true" >
         <shape xmlns:android="http://schemas.android.com/apk/res/android">

--- a/Android/app/src/main/res/layout/activity_main.xml
+++ b/Android/app/src/main/res/layout/activity_main.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/Android/app/src/main/res/layout/activity_question.xml
+++ b/Android/app/src/main/res/layout/activity_question.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/Android/app/src/main/res/layout/content_main.xml
+++ b/Android/app/src/main/res/layout/content_main.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/Android/app/src/main/res/layout/content_question.xml
+++ b/Android/app/src/main/res/layout/content_question.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/Android/app/src/main/res/layout/spinner_item.xml
+++ b/Android/app/src/main/res/layout/spinner_item.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"

--- a/Android/app/src/main/res/layout/spinner_value_layout.xml
+++ b/Android/app/src/main/res/layout/spinner_value_layout.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"

--- a/Android/app/src/main/res/menu/language_menu.xml
+++ b/Android/app/src/main/res/menu/language_menu.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <menu
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/Android/app/src/main/res/menu/menu_main.xml
+++ b/Android/app/src/main/res/menu/menu_main.xml
@@ -1,3 +1,19 @@
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/Image generation/01 Create Labeled Data.py
+++ b/Image generation/01 Create Labeled Data.py
@@ -1,3 +1,19 @@
+"""
+   Copyright 2018 Nirmal Adhikari, Lakshyana KC, Shreyasha Paudel, Kshitz Rimal, Nicolas Oritiz
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
 import itertools
 import pandas as pd
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Nirmal Adhikari,Lakshyana KC,Shreyasha Paudel,Kshitz Rimal,Nicolas Oritiz
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The LICENSE file itself doesn't need to have the authors in it, instead, you add it to the top of custom files. This pull request adds it to the custom Python, Java, and XML files.